### PR TITLE
README: fix website link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ECE 4/599
 =======
 
-This is the [website](mem-systems-site-w25) for a new grad course at OSU on modern memory systems.
+This is the [website](https://khale.github.io/mem-systems-w25/) for a new grad course at OSU on modern memory systems.
 It uses [Zola][].
 
 [zola]: https://www.getzola.org


### PR DESCRIPTION
Fix the URL in the README.md.  To preview this, look at the link on the fork branch:

https://github.com/eugenecohen-osu/mem-systems-w25/tree/readme_site_link_fix?tab=readme-ov-file
